### PR TITLE
Fix avatar upcase extension

### DIFF
--- a/lib/division_web/uploaders/avatar.ex
+++ b/lib/division_web/uploaders/avatar.ex
@@ -14,7 +14,12 @@ defmodule Division.Avatar do
 
   # Whitelist file extensions:
   def validate({file, _}) do
-    ~w(.jpg .jpeg .gif .png) |> Enum.member?(Path.extname(file.file_name))
+    ~w(.jpg .jpeg .gif .png)
+    |> Enum.member?(
+         file.file_name
+         |> Path.extname
+         |> String.downcase
+       )
   end
 
   # Define a thumbnail transformation:


### PR DESCRIPTION
When I tried upload avatar, where extension was upcased (.JPG), i got an error. But as i see, this is a valid filename