### PR TITLE
Fix: avatar hasn't been persisted during registration

### DIFF
--- a/lib/division_web/controllers/user_controller.ex
+++ b/lib/division_web/controllers/user_controller.ex
@@ -17,6 +17,7 @@ defmodule DivisionWeb.UserController do
   def create(conn, %{"user" => user_params}) do
     case Accounts.create_user(user_params) do
       {:ok, user} ->
+        Accounts.update_user(user, %{"avatar" => user_params["avatar"]})
         conn
         |> put_session(:current_user_id, user.id)
         |> put_flash(:info, "Registered successfully.")

--- a/lib/division_web/controllers/user_controller.ex
+++ b/lib/division_web/controllers/user_controller.ex
@@ -15,7 +15,7 @@ defmodule DivisionWeb.UserController do
   end
 
   def create(conn, %{"user" => user_params}) do
-    case Accounts.create_user(user_params) do
+    case Accounts.create_user(user_params |> Map.delete("avatar")) do
       {:ok, user} ->
         Accounts.update_user(user, %{"avatar" => user_params["avatar"]})
         conn


### PR DESCRIPTION
Issue https://github.com/cademy/division/issues/10

https://github.com/cademy/division/blob/bd138a6c13ec4f4b988b428f09fd29f3e700a5df/lib/division_web/uploaders/avatar.ex#L35-L38
Because we use `user.id` as storage scope for avatar. We must upload the avatar after the user got the id. Otherwise, we upload the avatar to the root folder `uploads/user/avatars`.
In my implementation, I first create a user without an avatar, and then upload an avatar for him in a separate step.

https://github.com/cademy/division/blob/4cf93cd29ba1391ac935ea09660c0a72c93ac3b8/lib/division_web/controllers/user_controller.ex#L17-L20

