### PR TITLE
Updated chat's text_input and now text_input don't show previous messages

### DIFF
--- a/lib/division_web/templates/chat/show.html.leex
+++ b/lib/division_web/templates/chat/show.html.leex
@@ -2,7 +2,7 @@
 
 <div class="form-group">
   <%= form_for @message, "#", [phx_change: :typing, phx_submit: :message], fn _f -> %>
-    <%= text_input :message, :content, value: @message.changes[:content], phx_blur: "stop_typing", placeholder: "write your message here..." %>
+    <%= text_input :message, :content, value: @message.changes[:content], phx_blur: "stop_typing", placeholder: "write your message here...", autocomplete: "off" %>
     <%= hidden_input :message, :user_id, value: @current_user.id  %>
     <%= hidden_input :message, :chat_id, value: @chat.id  %>
     <%= submit "submit" %>


### PR DESCRIPTION
Updated chat's text_input and now text_input don't show previous messages. Fixes #17 