### PR TITLE
Add highlight messages if they were addressed to you

### DIFF
--- a/assets/css/division.css
+++ b/assets/css/division.css
@@ -3,5 +3,5 @@ body {
 }
 
 .addressed-message {
-  background-color: orchid;
+  background-color: #ffff80;
 }

--- a/assets/css/division.css
+++ b/assets/css/division.css
@@ -1,3 +1,7 @@
 body {
   color: #666;
 }
+
+.addressed-message {
+  background-color: lightgray;
+}

--- a/assets/css/division.css
+++ b/assets/css/division.css
@@ -3,5 +3,5 @@ body {
 }
 
 .addressed-message {
-  background-color: lightgray;
+  background-color: orchid;
 }

--- a/lib/division_web/templates/chat/show.html.leex
+++ b/lib/division_web/templates/chat/show.html.leex
@@ -10,11 +10,7 @@
 </div>
 
 <%= for message <- @chat.messages do %>
-  <%= if addressed_message?(message.content, @current_user.username) do %>
-  <p class="addressed-message">
-  <% else %>
-  <p>
-  <% end %>
+  <p class="<%= addressed_message?(message.content, @current_user.username) %>">
     <%= message.user.username %>: <%= message.content %>
   </p>
 <% end %>

--- a/lib/division_web/templates/chat/show.html.leex
+++ b/lib/division_web/templates/chat/show.html.leex
@@ -10,7 +10,11 @@
 </div>
 
 <%= for message <- @chat.messages do %>
+  <%= if addressed_message?(message.content, @current_user.username) do %>
+  <p class="addressed-message">
+  <% else %>
   <p>
+  <% end %>
     <%= message.user.username %>: <%= message.content %>
   </p>
 <% end %>

--- a/lib/division_web/views/chat_view.ex
+++ b/lib/division_web/views/chat_view.ex
@@ -1,7 +1,10 @@
 defmodule DivisionWeb.ChatView do
   use DivisionWeb, :view
 
-  def addressed_message?(text, username) do
-    String.contains?(text, "@#{username}")
+  def addressed_message?(message, username) do
+    cond do
+      String.contains?(message, "@#{username}") -> "addressed-message"
+      true -> ""
+    end
   end
 end

--- a/lib/division_web/views/chat_view.ex
+++ b/lib/division_web/views/chat_view.ex
@@ -1,3 +1,7 @@
 defmodule DivisionWeb.ChatView do
   use DivisionWeb, :view
+
+  def addressed_message?(text, username) do
+    String.contains?(text, "@#{username}")
+  end
 end

--- a/test/division_web/views/chat_view_test.exs
+++ b/test/division_web/views/chat_view_test.exs
@@ -1,0 +1,15 @@
+defmodule DivisionWeb.ChatViewTest do
+  use DivisionWeb.ConnCase, async: true
+
+  alias DivisionWeb.ChatView
+
+  test "message addressed when contains username start's with @ symbol" do
+    style = ChatView.addressed_message?("test @username", "username")
+    assert style == "addressed-message"
+  end
+
+  test "message not addressed when contains username not start's with @ symbol" do
+    style = ChatView.addressed_message?("test", "username")
+    assert style == ""
+  end
+end


### PR DESCRIPTION
Pull request for issue #20. 
1) Added a simple CSS style for messages addressed to you
![Screenshot_20191013_225641](https://user-images.githubusercontent.com/39673277/66719818-fbeb5400-ee0d-11e9-8e5a-8f0168da5bab.png)

2) Added class for `<p>` if message addresse
3) Added helper in `DivisionWeb.ChatView` 